### PR TITLE
Json objects

### DIFF
--- a/SBOMResearcher.ps1
+++ b/SBOMResearcher.ps1
@@ -657,4 +657,4 @@ function SBOMResearcher {
     }
 }
 
-SBOMResearcher -SBOMPath "C:\Temp\SBOMResearcher\sboms" -wrkDir "C:\Temp\SBOMResearcher\reports" -PrintLicenseInfo $true
+#SBOMResearcher -SBOMPath "C:\Temp\SBOMResearcher\sboms" -wrkDir "C:\Temp\SBOMResearcher\reports" -PrintLicenseInfo $true


### PR DESCRIPTION
Move from simple report output to holding license and vulnerability info in JSON objects. Added in a calculator for the CVSS scores instead of just the link. This will add flexibility to tie this into a pipeline job and create gates based on vulnerabilities found.